### PR TITLE
Change way to inject services to remove errors widgets app (angular 6)

### DIFF
--- a/projects/ngx-location-viewer/src/lib/ngx-location-viewer.module.ts
+++ b/projects/ngx-location-viewer/src/lib/ngx-location-viewer.module.ts
@@ -13,6 +13,7 @@ import { LayerComponent } from './components/layer-management/layer/layer.compon
 import { FormsModule } from '@angular/forms';
 import { LayerLegendComponent } from './components/layer-management/layer-legend/layer-legend.component';
 import { GeoApiService } from './services/geoapi.service';
+import { LocationViewerHelper } from './services/location-viewer.helper';
 
 @NgModule({
   declarations: [NgxLocationViewerComponent, LayerManagementComponent, LayerComponent, LayerLegendComponent],
@@ -27,7 +28,8 @@ import { GeoApiService } from './services/geoapi.service';
     MAP_SERVICE_PROVIDER,
     MapServerService,
     LayerService,
-    GeoApiService
+    GeoApiService,
+    LocationViewerHelper
   ]
 })
 export class LocationViewerModule { }

--- a/projects/ngx-location-viewer/src/lib/services/location-viewer.helper.ts
+++ b/projects/ngx-location-viewer/src/lib/services/location-viewer.helper.ts
@@ -3,9 +3,7 @@ import { AddressDetail } from '../types/geoapi/address-detail.model';
 import { LatLng } from '../types/leaflet.types';
 import { OperationalLayerOptions, OperationalMarker } from '../types/operational-layer-options.model';
 
-@Injectable({
-    providedIn: 'root',
-})
+@Injectable()
 /**
  * Provide helper functions
  */

--- a/projects/ngx-location-viewer/src/lib/services/ngx-location-viewer.service.ts
+++ b/projects/ngx-location-viewer/src/lib/services/ngx-location-viewer.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 
-@Injectable({
-    providedIn: 'root',
-})
+@Injectable()
 export class NgxLocationViewerService {
     constructor() {}
 }


### PR DESCRIPTION
If services used providedin: 'root' widget app would throw error:
"export 'ɵɵdefineInjectable' was not found in '@angular/core'

Following article gives explanation why:
https://github.com/angular/angular/issues/30413
==> Recently, defineInjectable was renamed to ɵɵdefineInjectable and defineInjectable was deprecated. This makes pre-8 libraries compatible with v8, however v8 compiled libraries will not be compatible with pre-8 consumers.
